### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,6 +355,8 @@ function clearOneTimers() {
 			AB.oneTimers[oneTimer].owned = false;
 		}
 	}
+	//ring levels above 10 do stuff even if ring isn't equipped
+	AB.rings.level = 1;
   ABC.modifiedAB();
 }
 


### PR DESCRIPTION
ring levels above 10 do stuff even if ring isn't equipped, so ring level is now cleared in the clearOneTimers() functions