### PR TITLE
Don't include yellow items in Add Item automation

### DIFF
--- a/src/controller/extra/get.ts
+++ b/src/controller/extra/get.ts
@@ -50,7 +50,9 @@ export function getOppositesLimit(items?: (keyof IABTypes["items"])[]) {
     const allItems = getItemsOwned();
     const opposites = [] as (keyof IABTypes["items"])[];
     for (const item of allItems) {
-        if (!items.includes(item)) opposites.push(item);
+        if (!items.includes(item) && getItem(item).state === Trinary.No) {
+            opposites.push(item);
+        }
     }
     return opposites;
 }


### PR DESCRIPTION
This is attempting to resolve the bug where running Add Item with an item marked yellow desyncs the UI with the backend.

Steps to replicate bug in live:

1. Refresh page
2. Mark Sword (or any item) yellow
3. Run Best Grades: no upgrades simulated
4. Run Add Item: Mask and Sword simulated (I'm not sure what the expected behavior for yellow items should be here)
5. Run Add Item again: Only Mask is simulated (Unexpected)
6. Run Best Grades again: Sword simulated (Also unexpected)

What I think is going on:

- [This conditional](https://github.com/GodNooNoo/godnoonoo.github.io/blob/master/src/controller/extra/get.ts#L16) excludes yellow items from itemsToRun
- [Here](https://github.com/GodNooNoo/godnoonoo.github.io/blob/master/src/controller/extra/get.ts#L53) the list is inverted, so yellow items are included in the list for Add Item
- When the yellow item gets simulated, equipItemBackendOnly eventually runs [cycleTrinaryBool](https://github.com/GodNooNoo/godnoonoo.github.io/blob/master/src/controller/itemEquipController.ts#L55) on the yellow item twice - once before simulating it and once after
- [cycleTrinaryBool](https://github.com/GodNooNoo/godnoonoo.github.io/blob/master/src/utility.ts#L197-L198) changes the yellow item from `But` to `No`, and then from `No` to `Yes`, without updating its status in the UI.
- Now the backend thinks the item is orange, but the frontend thinks it's yellow

My change avoids simulating yellow items in Add Item so this behavior never gets triggered.